### PR TITLE
Add reverse value bindings

### DIFF
--- a/context/context.h
+++ b/context/context.h
@@ -16,8 +16,8 @@ typedef struct _engine_context {
 
 engine_context *context_new(void *parent);
 void context_exec(engine_context *context, char *filename);
-void context_eval(engine_context *context, char *script);
-void context_bind(engine_context *context, char *name, void *zvalptr);
+void *context_eval(engine_context *context, char *script);
+void context_bind(engine_context *context, char *name, void *value);
 int context_write(engine_context *context, const char *str, unsigned int len);
 void context_destroy(engine_context *context);
 

--- a/value/value.c
+++ b/value/value.c
@@ -93,43 +93,67 @@ void value_object_add_property(engine_value *obj, const char *key, engine_value 
 }
 
 int value_get_long(engine_value *val) {
-	// Covert value to long if needed.
-	if (Z_TYPE_P(val->value) != IS_LONG) {
-		convert_to_long(val->value);
-		val->kind = Z_TYPE_P(val->value);
+	// Return value directly if already in correct type.
+	if (val->kind == IS_LONG) {
+		return Z_LVAL_P(val->value);
 	}
 
-	return Z_LVAL_P(val->value);
+	zval *tmp = value_copy(val->value);
+
+	convert_to_long(tmp);
+	long v = Z_LVAL_P(tmp);
+
+	zval_dtor(tmp);
+
+	return v;
 }
 
 double value_get_double(engine_value *val) {
-	// Covert value to double if needed.
-	if (Z_TYPE_P(val->value) != IS_DOUBLE) {
-		convert_to_double(val->value);
-		val->kind = Z_TYPE_P(val->value);
+	// Return value directly if already in correct type.
+	if (val->kind == IS_DOUBLE) {
+		return Z_DVAL_P(val->value);
 	}
 
-	return Z_DVAL_P(val->value);
+	zval *tmp = value_copy(val->value);
+
+	convert_to_double(tmp);
+	double v = Z_DVAL_P(tmp);
+
+	zval_dtor(tmp);
+
+	return v;
 }
 
 bool value_get_bool(engine_value *val) {
-	// Covert value to long if needed.
-	if (Z_TYPE_P(val->value) != IS_BOOL) {
-		convert_to_boolean(val->value);
-		val->kind = Z_TYPE_P(val->value);
+	// Return value directly if already in correct type.
+	if (val->kind == IS_BOOL) {
+		return Z_BVAL_P(val->value);
 	}
 
-	return Z_BVAL_P(val->value);
+	zval *tmp = value_copy(val->value);
+
+	convert_to_boolean(tmp);
+	bool v = Z_BVAL_P(tmp);
+
+	zval_dtor(tmp);
+
+	return v;
 }
 
 char *value_get_string(engine_value *val) {
-	// Covert value to string if needed.
-	if (Z_TYPE_P(val->value) != IS_STRING) {
-		convert_to_cstring(val->value);
-		val->kind = Z_TYPE_P(val->value);
+	// Return value directly if already in correct type.
+	if (val->kind == IS_STRING) {
+		return Z_STRVAL_P(val->value);
 	}
 
-	return Z_STRVAL_P(val->value);
+	zval *tmp = value_copy(val->value);
+
+	convert_to_cstring(tmp);
+	char *v = Z_STRVAL_P(tmp);
+
+	zval_dtor(tmp);
+
+	return v;
 }
 
 void value_destroy(engine_value *val) {

--- a/value/value.c
+++ b/value/value.c
@@ -4,77 +4,135 @@
 
 #include <errno.h>
 #include <stdbool.h>
-
 #include <main/php.h>
 
 #include "value.h"
 
-void *value_create_long(long int value) {
-	zval *v;
+engine_value *value_new(zval *zv) {
+	engine_value *value = (engine_value *) malloc((sizeof(engine_value)));
+	if (value == NULL) {
+		errno = 1;
+		return NULL;
+	}
 
-	MAKE_STD_ZVAL(v);
-	ZVAL_LONG(v, value);
+	value->value = zv;
+	value->kind = Z_TYPE_P(zv);
 
-	return (void *) v;
+	errno = 0;
+	return value;
 }
 
-void *value_create_double(double value) {
-	zval *v;
-
-	MAKE_STD_ZVAL(v);
-	ZVAL_DOUBLE(v, value);
-
-	return (void *) v;
+int value_kind(engine_value *val) {
+	return Z_TYPE_P(val->value);
 }
 
-void *value_create_bool(bool value) {
-	zval *v;
+engine_value *value_create_long(long int value) {
+	zval *zv;
 
-	MAKE_STD_ZVAL(v);
-	ZVAL_BOOL(v, value);
+	MAKE_STD_ZVAL(zv);
+	ZVAL_LONG(zv, value);
 
-	return (void *) v;
+	return value_new(zv);
 }
 
-void *value_create_string(char *value) {
-	zval *v;
+engine_value *value_create_double(double value) {
+	zval *zv;
 
-	MAKE_STD_ZVAL(v);
-	ZVAL_STRING(v, value, 1);
+	MAKE_STD_ZVAL(zv);
+	ZVAL_DOUBLE(zv, value);
 
-	return (void *) v;
+	return value_new(zv);
 }
 
-void *value_create_array(unsigned int size) {
-	zval *v;
+engine_value *value_create_bool(bool value) {
+	zval *zv;
 
-	MAKE_STD_ZVAL(v);
-	array_init_size(v, size);
+	MAKE_STD_ZVAL(zv);
+	ZVAL_BOOL(zv, value);
 
-	return (void *) v;
+	return value_new(zv);
 }
 
-void value_array_set_index(void *arr, unsigned long idx, void *val) {
-	add_index_zval((zval *) arr, idx, (zval *) val);
+engine_value *value_create_string(char *value) {
+	zval *zv;
+
+	MAKE_STD_ZVAL(zv);
+	ZVAL_STRING(zv, value, 1);
+
+	return value_new(zv);
 }
 
-void value_array_set_key(void *arr, const char *key, void *val) {
-	add_assoc_zval((zval *) arr, key, (zval *) val);
+engine_value *value_create_array(unsigned int size) {
+	zval *zv;
+
+	MAKE_STD_ZVAL(zv);
+	array_init_size(zv, size);
+
+	return value_new(zv);
 }
 
-void *value_create_object() {
-	zval *v;
-
-	MAKE_STD_ZVAL(v);
-	object_init(v);
-
-	return (void *) v;
+void value_array_set_index(engine_value *arr, unsigned long idx, engine_value *val) {
+	add_index_zval(arr->value, idx, val->value);
 }
 
-void value_object_add_property(void *obj, const char *key, void *val) {
-	add_property_zval((zval *) obj, key, (zval *) val);
+void value_array_set_key(engine_value *arr, const char *key, engine_value *val) {
+	add_assoc_zval(arr->value, key, val->value);
 }
 
-void value_destroy(void *zvalptr) {
-	zval_dtor((zval *) zvalptr);
+engine_value *value_create_object() {
+	zval *zv;
+
+	MAKE_STD_ZVAL(zv);
+	object_init(zv);
+
+	return value_new(zv);
+}
+
+void value_object_add_property(engine_value *obj, const char *key, engine_value *val) {
+	add_property_zval(obj->value, key, val->value);
+}
+
+int value_get_long(engine_value *val) {
+	// Covert value to long if needed.
+	if (Z_TYPE_P(val->value) != IS_LONG) {
+		convert_to_long(val->value);
+		val->kind = Z_TYPE_P(val->value);
+	}
+
+	return Z_LVAL_P(val->value);
+}
+
+double value_get_double(engine_value *val) {
+	// Covert value to double if needed.
+	if (Z_TYPE_P(val->value) != IS_DOUBLE) {
+		convert_to_double(val->value);
+		val->kind = Z_TYPE_P(val->value);
+	}
+
+	return Z_DVAL_P(val->value);
+}
+
+bool value_get_bool(engine_value *val) {
+	// Covert value to long if needed.
+	if (Z_TYPE_P(val->value) != IS_BOOL) {
+		convert_to_boolean(val->value);
+		val->kind = Z_TYPE_P(val->value);
+	}
+
+	return Z_BVAL_P(val->value);
+}
+
+char *value_get_string(engine_value *val) {
+	// Covert value to string if needed.
+	if (Z_TYPE_P(val->value) != IS_STRING) {
+		convert_to_cstring(val->value);
+		val->kind = Z_TYPE_P(val->value);
+	}
+
+	return Z_STRVAL_P(val->value);
+}
+
+void value_destroy(engine_value *val) {
+	zval_dtor(val->value);
+	free(val);
 }

--- a/value/value.c
+++ b/value/value.c
@@ -23,7 +23,7 @@ engine_value *value_new(zval *zv) {
 }
 
 int value_kind(engine_value *val) {
-	return Z_TYPE_P(val->value);
+	return val->kind;
 }
 
 engine_value *value_create_long(long int value) {

--- a/value/value.go
+++ b/value/value.go
@@ -55,8 +55,6 @@ func (v *Value) Interface() interface{} {
 		return v.Float()
 	case Bool:
 		return v.Bool()
-	// case Array:
-	// 	return v.Map()
 	case String:
 		return v.String()
 	}

--- a/value/value.go
+++ b/value/value.go
@@ -11,26 +11,84 @@ package value
 //
 // #include <stdlib.h>
 // #include <stdbool.h>
+// #include <main/php.h>
 // #include "value.h"
 import "C"
 
 import (
-	"errors"
+	"fmt"
 	"reflect"
 	"unsafe"
 )
 
-var errInvalidType = errors.New("Cannot create value of unknown type")
+// Kind represents the specific kind of type represented in Value.
+type Kind int
+
+const (
+	Null Kind = iota
+	Long
+	Double
+	Bool
+	Array
+	Object
+	String
+)
 
 // Value represents a PHP value.
 type Value struct {
-	value unsafe.Pointer
+	value *C.struct__engine_value
+}
+
+// Kind returns the Value's concrete kind of type.
+func (v *Value) Kind() Kind {
+	return (Kind)(C.value_kind(v.value))
+}
+
+// Interface returns the internal PHP value as it lies, with no conversion step.
+// Attempting to call this method on an object value will return `nil`, as
+// conversion from objects to structs requires a struct definition to extract to.
+func (v *Value) Interface() interface{} {
+	switch v.Kind() {
+	case Long:
+		return v.Int()
+	case Double:
+		return v.Float()
+	case Bool:
+		return v.Bool()
+	// case Array:
+	// 	return v.Map()
+	case String:
+		return v.String()
+	}
+
+	return nil
+}
+
+// Int returns the internal PHP value as an integer, converting if necessary.
+func (v *Value) Int() int64 {
+	return (int64)(C.value_get_long(v.value))
+}
+
+// Float returns the internal PHP value as a floating point number, converting
+// if necessary.
+func (v *Value) Float() float64 {
+	return (float64)(C.value_get_double(v.value))
+}
+
+// Bool returns the internal PHP value as a boolean, converting if necessary.
+func (v *Value) Bool() bool {
+	return (bool)(C.value_get_bool(v.value))
+}
+
+// String returns the internal PHP value as a string, converting if necessary.
+func (v *Value) String() string {
+	return C.GoString(C.value_get_string(v.value))
 }
 
 // Ptr returns a pointer to the internal PHP value, and is mostly used for
 // passing to C functions.
 func (v *Value) Ptr() unsafe.Pointer {
-	return v.value
+	return unsafe.Pointer(v.value)
 }
 
 // Destroy removes all active references to the internal PHP value and frees
@@ -40,6 +98,10 @@ func (v *Value) Destroy() {
 		C.value_destroy(v.value)
 		v.value = nil
 	}
+}
+
+var errInvalidType = func(v interface{}) error {
+	return fmt.Errorf("Cannot create value of unknown type '%T'", v)
 }
 
 // New creates a PHP value representtion of a Go value val. Available bindings
@@ -58,29 +120,32 @@ func (v *Value) Destroy() {
 // receivers to PHP functions and classes are only available in the engine scope,
 // and must be predeclared before context execution.
 func New(val interface{}) (*Value, error) {
-	var ptr unsafe.Pointer
+	var ptr *C.struct__engine_value
+	var err error
 
 	// Determine value type and create PHP value from the concrete type.
 	v := reflect.ValueOf(val)
 	switch v.Kind() {
 	// Bind integer to PHP int type.
 	case reflect.Int:
-		ptr = C.value_create_long(C.long(v.Int()))
+		ptr, err = C.value_create_long(C.long(v.Int()))
 	// Bind floating point number to PHP double type.
 	case reflect.Float64:
-		ptr = C.value_create_double(C.double(v.Float()))
+		ptr, err = C.value_create_double(C.double(v.Float()))
 	// Bind boolean to PHP bool type.
 	case reflect.Bool:
-		ptr = C.value_create_bool(C.bool(v.Bool()))
+		ptr, err = C.value_create_bool(C.bool(v.Bool()))
 	// Bind string to PHP string type.
 	case reflect.String:
 		str := C.CString(v.String())
 
-		ptr = C.value_create_string(str)
+		ptr, err = C.value_create_string(str)
 		C.free(unsafe.Pointer(str))
 	// Bind slice to PHP indexed array type.
 	case reflect.Slice:
-		ptr = C.value_create_array(C.uint(v.Len()))
+		if ptr, err = C.value_create_array(C.uint(v.Len())); err != nil {
+			break
+		}
 
 		for i := 0; i < v.Len(); i++ {
 			vs, err := New(v.Index(i).Interface())
@@ -89,14 +154,16 @@ func New(val interface{}) (*Value, error) {
 				return nil, err
 			}
 
-			C.value_array_set_index(ptr, C.ulong(i), vs.Ptr())
+			C.value_array_set_index(ptr, C.ulong(i), vs.value)
 		}
 	// Bind map (with integer or string keys) to PHP associative array type.
 	case reflect.Map:
 		kt := v.Type().Key().Kind()
 
 		if kt == reflect.Int || kt == reflect.String {
-			ptr = C.value_create_array(C.uint(v.Len()))
+			if ptr, err = C.value_create_array(C.uint(v.Len())); err != nil {
+				break
+			}
 
 			for _, key := range v.MapKeys() {
 				kv, err := New(v.MapIndex(key).Interface())
@@ -106,21 +173,23 @@ func New(val interface{}) (*Value, error) {
 				}
 
 				if kt == reflect.Int {
-					C.value_array_set_index(ptr, C.ulong(key.Int()), kv.Ptr())
+					C.value_array_set_index(ptr, C.ulong(key.Int()), kv.value)
 				} else {
 					str := C.CString(key.String())
 
-					C.value_array_set_key(ptr, str, kv.Ptr())
+					C.value_array_set_key(ptr, str, kv.value)
 					C.free(unsafe.Pointer(str))
 				}
 			}
 		} else {
-			return nil, errInvalidType
+			return nil, errInvalidType(val)
 		}
 	// Bind struct to PHP object (stdClass) type.
 	case reflect.Struct:
 		vt := v.Type()
-		ptr = C.value_create_object()
+		if ptr, err = C.value_create_object(); err != nil {
+			break
+		}
 
 		for i := 0; i < v.NumField(); i++ {
 			// Skip unexported fields.
@@ -136,12 +205,30 @@ func New(val interface{}) (*Value, error) {
 
 			str := C.CString(vt.Field(i).Name)
 
-			C.value_object_add_property(ptr, str, fv.Ptr())
+			C.value_object_add_property(ptr, str, fv.value)
 			C.free(unsafe.Pointer(str))
 		}
 	default:
-		return nil, errInvalidType
+		return nil, errInvalidType(val)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create PHP value from Go value '%v'", val)
 	}
 
 	return &Value{value: ptr}, nil
+}
+
+// NewFromPtr creates a Value type from an existing PHP value pointer.
+func NewFromPtr(val unsafe.Pointer) (*Value, error) {
+	if val == nil {
+		return nil, fmt.Errorf("Cannot create value from `nil` pointer")
+	}
+
+	v, err := C.value_new((*C.zval)(val))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create PHP value from pointer")
+	}
+
+	return &Value{value: v}, nil
 }

--- a/value/value.h
+++ b/value/value.h
@@ -10,6 +10,16 @@ typedef struct _engine_value {
 	int kind;
 } engine_value;
 
+static inline zval *value_copy(zval *zv) {
+	zval *tmp;
+
+	ALLOC_ZVAL(tmp);
+	INIT_PZVAL_COPY(tmp, zv);
+	zval_copy_ctor(tmp);
+
+	return tmp;
+}
+
 engine_value *value_new(zval *zv);
 int value_kind(engine_value *val);
 void value_destroy(engine_value *val);

--- a/value/value.h
+++ b/value/value.h
@@ -5,15 +5,30 @@
 #ifndef VALUE_H
 #define VALUE_H
 
-void *value_create_long(long int value);
-void *value_create_double(double value);
-void *value_create_bool(bool value);
-void *value_create_string(char *value);
-void *value_create_array(unsigned int size);
-void value_array_set_index(void *arr, unsigned long idx, void *val);
-void value_array_set_key(void *arr, const char *key, void *val);
-void *value_create_object();
-void value_object_add_property(void *obj, const char *key, void *val);
-void value_destroy(void *zvalptr);
+typedef struct _engine_value {
+	zval *value;
+	int kind;
+} engine_value;
+
+engine_value *value_new(zval *zv);
+int value_kind(engine_value *val);
+void value_destroy(engine_value *val);
+
+engine_value *value_create_long(long int value);
+engine_value *value_create_double(double value);
+engine_value *value_create_bool(bool value);
+engine_value *value_create_string(char *value);
+
+engine_value *value_create_array(unsigned int size);
+void value_array_set_index(engine_value *arr, unsigned long idx, engine_value *val);
+void value_array_set_key(engine_value *arr, const char *key, engine_value *val);
+
+engine_value *value_create_object();
+void value_object_add_property(engine_value *obj, const char *key, engine_value *val);
+
+int value_get_long(engine_value *val);
+double value_get_double(engine_value *val);
+bool value_get_bool(engine_value *val);
+char *value_get_string(engine_value *val);
 
 #endif


### PR DESCRIPTION
Expressions executed in the `Context.Eval` method can now return a value, which will be passed to the Go caller, and can be used as a regular Go value.