### PR TITLE
 Context: Fix variable scoping issues for `Eval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ func main() {
 
 The above will execute script file `index.php` located in the current folder and will write any output to the `io.Writer` assigned to `Context.Output` (in this case, the standard output).
 
+### Binding and returning variables
+
+The following example demonstrates binding a Go variable to the running PHP context, and returning a PHP variable for use in Go:
+
+```go
+package main
+
+import (
+    "fmt"
+    php "github.com/deuill/go-php"
+)
+
+func main() {
+    engine, _ := php.New()
+    context, _ := engine.NewContext()
+
+    var str string = "Hello"
+    context.Bind("var", str)
+
+    val, _ := context.Eval("return $var.' World';")
+    fmt.Printf("%s", val.Interface())
+    // Prints 'Hello World' back to the user.
+
+    engine.Destroy()
+}
+```
+
+A string value "Hello" is attached using `Context.Bind` under a name `var` (available in PHP as `$var`). A script is executed inline using `Context.Eval`, combinding the attached value with a PHP string and returning it to the user.
+
+Finally, the value is returned as an `interface{}` using `Value.Interface()` (one could also use `Value.String()`, though the both are equivalent in this case).
+
 ## License
 
 All code in this repository is covered by the terms of the MIT License, the full text of which can be found in the LICENSE file.

--- a/engine/context.go
+++ b/engine/context.go
@@ -31,7 +31,7 @@ type Context struct {
 	Header http.Header
 
 	context *C.struct__engine_context
-	values  map[string]*Value
+	values  []*Value
 }
 
 // NewContext creates a new execution context for the active engine and returns
@@ -39,7 +39,7 @@ type Context struct {
 func NewContext() (*Context, error) {
 	ctx := &Context{
 		Header: make(http.Header),
-		values: make(map[string]*Value),
+		values: make([]*Value, 0),
 	}
 
 	ptr, err := C.context_new(unsafe.Pointer(ctx))
@@ -66,7 +66,7 @@ func (c *Context) Bind(name string, val interface{}) error {
 	defer C.free(unsafe.Pointer(n))
 
 	C.context_bind(c.context, n, v.Ptr())
-	c.values[name] = v
+	c.values = append(c.values, v)
 
 	return nil
 }
@@ -104,6 +104,8 @@ func (c *Context) Eval(script string) (*Value, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.values = append(c.values, val)
 
 	return val, nil
 }

--- a/engine/context.go
+++ b/engine/context.go
@@ -90,11 +90,7 @@ func (c *Context) Exec(filename string) error {
 // containing the PHP value returned by the expression, if any. Any output
 // produced is written context's pre-defined io.Writer instance.
 func (c *Context) Eval(script string) (*Value, error) {
-	// When PHP compiles code with a non-NULL return value expected, it simply
-	// prepends a `return` call to the code, thus breaking simple scripts that
-	// would otherwise work. Thus, we need to wrap the code in a closure, and
-	// call it immediately.
-	s := C.CString("call_user_func(function(){" + script + "});")
+	s := C.CString(script)
 	defer C.free(unsafe.Pointer(s))
 
 	result, err := C.context_eval(c.context, s)

--- a/engine/context_test.go
+++ b/engine/context_test.go
@@ -260,19 +260,14 @@ func TestContextBind(t *testing.T) {
 	c, _ := NewContext()
 	c.Output = &w
 
-	script, err := NewScript("bind.php", "<?php $i = (isset($i)) ? $i += 1 : 0; echo serialize($$i);")
-	if err != nil {
-		t.Fatalf("Could not create temporary file for testing: %s", err)
-	}
-
 	for i, tt := range bindTests {
-		if err := c.Bind(fmt.Sprintf("%d", i), tt.value); err != nil {
+		if err := c.Bind(fmt.Sprintf("t%d", i), tt.value); err != nil {
 			t.Errorf("Context.Bind('%v'): %s", tt.value, err)
 			continue
 		}
 
-		if err := c.Exec(script.Name()); err != nil {
-			t.Errorf("Context.Exec(): %s", err)
+		if _, err := c.Eval(fmt.Sprintf("echo serialize($t%d);", i)); err != nil {
+			t.Errorf("Context.Eval(): %s", err)
 			continue
 		}
 
@@ -284,7 +279,6 @@ func TestContextBind(t *testing.T) {
 		}
 	}
 
-	script.Remove()
 	c.Destroy()
 }
 

--- a/engine/include/php5/_context.h
+++ b/engine/include/php5/_context.h
@@ -9,4 +9,39 @@
 	ZEND_SET_SYMBOL(EG(active_symbol_table), n, v); \
 } while (0)
 
+#define CONTEXT_EXECUTE(o, v) do {                  \
+	zend_op_array *oparr = EG(active_op_array);     \
+	zval *retval=NULL;                              \
+	zval **retvalptr = EG(return_value_ptr_ptr);    \
+	zend_op **opline = EG(opline_ptr);              \
+	int interact = CG(interactive);                 \
+	EG(return_value_ptr_ptr) = &retval;             \
+	EG(active_op_array) = o;                        \
+	EG(no_extensions) = 1;                          \
+	if (!EG(active_symbol_table)) {                 \
+		zend_rebuild_symbol_table();                \
+	}                                               \
+	CG(interactive) = 0;                            \
+	zend_try {                                      \
+		zend_execute(o);                            \
+	} zend_catch {                                  \
+		destroy_op_array(o);                        \
+		efree(o);                                   \
+		zend_bailout();                             \
+	} zend_end_try();                               \
+	destroy_op_array(o);                            \
+	efree(o);                                       \
+	CG(interactive) = interact;                     \
+	if (retval) {                                   \
+		ZVAL_COPY_VALUE(v, retval);                 \
+		zval_copy_ctor(v);                          \
+	} else {                                        \
+		ZVAL_NULL(v);                               \
+	}                                               \
+	EG(no_extensions)=0;                            \
+	EG(opline_ptr) = opline;                        \
+	EG(active_op_array) = oparr;                    \
+	EG(return_value_ptr_ptr) = retvalptr;           \
+} while (0)
+
 #endif

--- a/engine/include/php7/_context.h
+++ b/engine/include/php7/_context.h
@@ -9,4 +9,19 @@
 	zend_hash_str_update(&EG(symbol_table), n, strlen(n), v); \
 } while (0)
 
+#define CONTEXT_EXECUTE(o, v) do {            \
+	EG(no_extensions) = 1;                    \
+	zend_try {                                \
+		ZVAL_NULL(v);                         \
+		zend_execute(o, v);                   \
+	} zend_catch {                            \
+		destroy_op_array(o);                  \
+		efree_size(o, sizeof(zend_op_array)); \
+		zend_bailout();                       \
+	} zend_end_try();                         \
+	destroy_op_array(o);                      \
+	efree_size(o, sizeof(zend_op_array));     \
+	EG(no_extensions) = 0;                    \
+} while (0)
+
 #endif

--- a/engine/include/php7/_receiver.h
+++ b/engine/include/php7/_receiver.h
@@ -31,12 +31,13 @@
 #define RECEIVER_FUNC_SET_ARGFLAGS(f) zend_set_function_arg_flags((zend_function *) f);
 
 #define RECEIVER_OBJECT(o) (o)
-#define RECEIVER_OBJECT_CREATE(r, t) do {                                     \
-	r = ecalloc(1, sizeof(engine_receiver) + zend_object_properties_size(t)); \
-	zend_object_std_init(&r->obj, t);                                         \
-	object_properties_init(&r->obj, t);                                       \
-	r->obj.handlers = &receiver_handlers;                                     \
-	return &r->obj;                                                           \
+#define RECEIVER_OBJECT_CREATE(r, t) do {  \
+	r = emalloc(sizeof(engine_receiver));  \
+	memset(r, 0, sizeof(engine_receiver)); \
+	zend_object_std_init(&r->obj, t);      \
+	object_properties_init(&r->obj, t);    \
+	r->obj.handlers = &receiver_handlers;  \
+	return &r->obj;                        \
 } while (0)
 
 #define RECEIVER_OBJECT_DESTROY(r) do { \


### PR DESCRIPTION
Previously, `Context.Eval` relied on Zend's `zend_eval_script` function for executing arbitrary strings. Unfortunately, the above contains a curious bit of functionality where the string passed is prepended with a `return` statement depending on whether or not a zval is passed for writing the return value.

This, of course breaks all but the simplest scripts, as we always write the return value to a zval (whether the user calling `Context.Eval` is to use the return value is another matter entirely).

This commit changes the implementation to a more direct (and therefore more controllable) approach. Some tests have been changed to cover this bug.