### PR TITLE
Fix the Zend inclusion path for PHP5

### DIFF
--- a/engine/php5.go
+++ b/engine/php5.go
@@ -3,6 +3,6 @@
 package engine
 
 // #cgo CFLAGS: -I/usr/include/php5 -I/usr/include/php5/main -I/usr/include/php5/TSRM
-// #cgo CFLAGS: -I/usr/include/Zend -Iinclude/php5
+// #cgo CFLAGS: -I/usr/include/php5/Zend -Iinclude/php5
 // #cgo LDFLAGS: -lphp5
 import "C"


### PR DESCRIPTION
Tested this morning, this include directive was "wrong". Don't know if some distribution use `/usr/include/Zend`, so maybe you will want to add a new include line rather than modifying this one.