### PR TITLE
Fix issues with older versions of PHP and GCC

### DIFF
--- a/engine/context.c
+++ b/engine/context.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include <main/php.h>
 #include <main/php_main.h>

--- a/engine/src/php5/_value.c
+++ b/engine/src/php5/_value.c
@@ -31,9 +31,20 @@ static int _value_current_key_get(HashTable *ht, char **str_index, ulong *num_in
 
 static void _value_current_key_set(HashTable *ht, engine_value *val) {
 	zval *tmp;
+	char *key;
+	unsigned long index;
 
 	MAKE_STD_ZVAL(tmp);
-	zend_hash_get_current_key_zval(ht, tmp);
+
+	switch (_value_current_key_get(ht, &key, &index)) {
+	case HASH_KEY_IS_STRING:
+		ZVAL_STRING(tmp, key, 1);
+		break;
+	case HASH_KEY_IS_LONG:
+		ZVAL_LONG(tmp, index);
+		break;
+	}
+
 	add_next_index_zval(val->internal, tmp);
 }
 

--- a/engine/value.c
+++ b/engine/value.c
@@ -224,7 +224,7 @@ char *value_get_string(engine_value *val) {
 		break;
 	default:
 		value_copy(&tmp, val->internal);
-		convert_to_cstring(&tmp);
+		convert_to_string(&tmp);
 	}
 
 	int len = Z_STRLEN(tmp) + 1;


### PR DESCRIPTION
This (hopefully) fixes issues with older versions of GCC (4.x) and PHP (5.4.x) that appear on some older versions of Red Hat and CentOS, as mainly used by Amazon AMIs on AWS.
