### PR TITLE
php7: Allow for additional `php7.debian` build tag

### DIFF
--- a/engine/php5.go
+++ b/engine/php5.go
@@ -1,4 +1,4 @@
-// +build !php7
+// +build !php7,!php7.debian
 
 package engine
 

--- a/engine/php7-debian.go
+++ b/engine/php7-debian.go
@@ -1,0 +1,12 @@
+// +build php7.debian
+//
+// Build tags specific to Debian (and Debian-derived, such as Ubuntu) distributions.
+// Debian builds its PHP7 packages with non-standard naming conventions for include
+// and library paths, so we need a specific build tag for building against those
+// packages.
+
+package engine
+
+// #cgo CFLAGS: -I/usr/include/php/20151012 -Iinclude/php7 -Isrc/php7
+// #cgo LDFLAGS: -lphp7.0
+import "C"


### PR DESCRIPTION
The additional `php7.debian` build tag allows Go-PHP to be built against PHP7 on Debian (and Debian-derived, such as Ubuntu) distributions. This additional build tag is required due to the non-standard include and library file locations.

Relates-To: #26