### PR TITLE
Update PHP versions for Travis, move Dockerfile to 'golang' image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 php:
-  - 5.6.31
-  - 7.0.23
-  - 7.1.9
+  - 5.6.33
+  - 7.0.27
+  - 7.1.13
+  - 7.2.1
 
 sudo: required
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:stable-slim
+FROM golang:1.9-stretch
 
 # The full PHP version to target, i.e. "7.1.10".
 ARG PHP_VERSION
 
 # Environment variables used across the build.
-ENV PHP_URL="https://secure.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror" PHP_ASC_URL="https://secure.php.net/get/php-${PHP_VERSION}.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://secure.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror"
 ENV PHP_BASE_DIR="/tmp/php"
 ENV PHP_SRC_DIR="${PHP_BASE_DIR}/src"
 
@@ -17,15 +17,15 @@ ENV PHP_CPPFLAGS="${PHP_CFLAGS}"
 # will eventually transition to using the base `php` Docker images.
 ENV FETCH_DEPS="ca-certificates wget"
 RUN set -xe && \
-	apt-get update && apt-get install -y --no-install-recommends ${FETCH_DEPS} && \
-	mkdir -p ${PHP_BASE_DIR} && cd ${PHP_BASE_DIR} && \
-	wget -O php.tar.xz ${PHP_URL} && \
+    apt-get update && apt-get install -y --no-install-recommends ${FETCH_DEPS} && \
+    mkdir -p ${PHP_BASE_DIR} && cd ${PHP_BASE_DIR} && \
+    wget -O php.tar.xz ${PHP_URL} && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ${FETCH_DEPS}
 
 # Build PHP library from source.
 ENV BUILD_DEPS="build-essential file libpcre3-dev dpkg-dev libcurl4-openssl-dev libedit-dev libsqlite3-dev libssl1.0-dev libxml2-dev zlib1g-dev"
 RUN set -xe && \
-	apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
+    apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
     export CFLAGS="${PHP_CFLAGS}" CPPFLAGS="${PHP_CPPFLAGS}" LDFLAGS="${PHP_LDFLAGS}" && \
     arch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && multiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)" && \
     if [ ! -d /usr/include/curl ]; \
@@ -45,11 +45,9 @@ RUN set -xe && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ${BUILD_DEPS}
 
 # Install runtime dependencies for testing, building packages etc, and clean up source.
-ENV RUNTIME_DEPS="build-essential git golang curl libedit2 libssl1.0 libxml2"
-ENV SOURCE_REPO="github.com/deuill/go-php"
-
+ENV RUNTIME_DEPS="build-essential git curl libedit2 libssl1.0 libxml2"
 RUN set -xe && \
-	apt-get update && apt-get install -y --no-install-recommends ${RUNTIME_DEPS} && \
+    apt-get update && apt-get install -y --no-install-recommends ${RUNTIME_DEPS} && \
     cd ${PHP_SRC_DIR} && make -j "$(nproc)" PHP_SAPI=embed install-sapi install-headers && \
     cd / && rm -Rf ${PHP_BASE_DIR} ${PHP_SRC_DIR}
 

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,10 @@ NAME        := go-php
 DESCRIPTION := PHP bindings for the Go programming language
 IMPORT_PATH := github.com/deuill/$(NAME)
 VERSION     := $(shell git describe --tags --always --dirty="-dev")
-DATE        := $(shell date '+%Y-%m-%d-%H%M UTC')
 
 # Generic build options.
-BUILD_OPTIONS  := -ldflags='-X "main.Version=$(VERSION)" -X "main.BuildTime=$(DATE)"'
 PACKAGE_FORMAT := tar.xz
-PHP_VERSION    := 7.1.10
+PHP_VERSION    := 7.0.27
 DOCKER_IMAGE   := deuill/$(NAME):$(PHP_VERSION)
 
 # Go build options.
@@ -21,12 +19,15 @@ PREFIX := /usr
 # Default Makefile options.
 VERBOSE :=
 
+# Variables to pass down to sub-invocations of 'make'.
+MAKE_OPTIONS := PACKAGE_FORMAT=$(PACKAGE_FORMAT) PHP_VERSION=$(PHP_VERSION) GO=$(GO) PREFIX=$(PREFIX) VERBOSE=$(VERBOSE)
+
 ## Default action. Build binary distribution.
 all: $(NAME)
 
 $(NAME): .build/env/GOPATH/.ok
 	@echo "Building '$(NAME)'..."
-	$Q $(GO) install $(if $(VERBOSE),-v) $(TAGS) $(BUILD_OPTIONS) $(IMPORT_PATH)
+	$Q $(GO) install $(if $(VERBOSE),-v) $(TAGS) $(IMPORT_PATH)
 
 ## Print internal package list.
 list: .build/env/GOPATH/.ok
@@ -96,7 +97,7 @@ docker-image:
 docker-%: docker-image
 	$Q docker run --rm -e GOPATH="/tmp/go"                                  \
 	              -v "$(CURDIR):/tmp/go/src/$(IMPORT_PATH)" $(DOCKER_IMAGE) \
-	                 "$(MAKE) -C /tmp/go/src/$(IMPORT_PATH) $(word 2,$(subst -, ,$@)) VERBOSE=$(VERBOSE) PHP_VERSION=$(PHP_VERSION)"
+	                 "$(MAKE) -C /tmp/go/src/$(IMPORT_PATH) $(word 2,$(subst -, ,$@)) $(MAKE_OPTIONS)"
 
 $(NAME)_$(VERSION).tar.xz: .build/dist/.ok
 	@echo "Building 'tar' package for '$(NAME)'..."


### PR DESCRIPTION
This adds PHP  7.2.1 as a new target, and updates existing PHP versions to their latest numbers. Be
aware that PHP 7.2.x is as-of-yet untested -- and expected to be buggy.