### PR TITLE
Update PHP versions, allow building static version of PHP in Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 php:
-  - 5.6.33
-  - 7.0.27
-  - 7.1.13
-  - 7.2.1
+  - 5.6.36
+  - 7.0.30
+  - 7.1.18
+  - 7.2.6
 
 sudo: required
 services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM golang:1.9-stretch
+FROM golang:1.10-stretch
 
 # The full PHP version to target, i.e. "7.1.10".
 ARG PHP_VERSION
+
+# Whether or not to build PHP as a static library.
+ARG STATIC=false
 
 # Environment variables used across the build.
 ENV PHP_URL="https://secure.php.net/get/php-${PHP_VERSION}.tar.xz/from/this/mirror"
@@ -25,12 +28,13 @@ RUN set -xe && \
 # Build PHP library from source.
 ENV BUILD_DEPS="build-essential file libpcre3-dev dpkg-dev libcurl4-openssl-dev libedit-dev libsqlite3-dev libssl1.0-dev libxml2-dev zlib1g-dev"
 RUN set -xe && \
-    apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS} && \
-    export CFLAGS="${PHP_CFLAGS}" CPPFLAGS="${PHP_CPPFLAGS}" LDFLAGS="${PHP_LDFLAGS}" && \
-    arch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && multiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)" && \
-    if [ ! -d /usr/include/curl ]; \
-        then ln -sT "/usr/include/$multiarch/curl" /usr/local/include/curl; \
-    fi && \
+    apt-get update && apt-get install -y --no-install-recommends ${BUILD_DEPS}; \
+    export CFLAGS="${PHP_CFLAGS}" CPPFLAGS="${PHP_CPPFLAGS}" LDFLAGS="${PHP_LDFLAGS}"; \
+    arch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" && multiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    [ "x$STATIC" = "xfalse" ] \
+        && options="--enable-embed" \
+        || options="--enable-embed=static --enable-static"; \
+    [ ! -d /usr/include/curl ] && ln -sT "/usr/include/$multiarch/curl" /usr/local/include/curl; \
     mkdir -p ${PHP_SRC_DIR} && cd ${PHP_SRC_DIR} && \
     tar -xJf ${PHP_BASE_DIR}/php.tar.xz -C . --strip-components=1 && \
     ./configure \
@@ -38,8 +42,9 @@ RUN set -xe && \
         --with-libdir="lib/$multiarch" \
         --with-pcre-regex=/usr \
         --disable-cgi --disable-fpm \
-        --enable-embed --enable-ftp --enable-mbstring \
+        --enable-ftp --enable-mbstring \
         --with-curl --with-libedit --with-openssl --with-zlib \
+        $options \
         && \
     make -j "$(nproc)" && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ${BUILD_DEPS}

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN set -xe && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ${BUILD_DEPS}
 
 # Install runtime dependencies for testing, building packages etc, and clean up source.
-ENV RUNTIME_DEPS="build-essential git curl libedit2 libssl1.0 libxml2"
+ENV RUNTIME_DEPS="build-essential git curl libssl1.0 libpcre3-dev libcurl4-openssl-dev libedit-dev libxml2-dev zlib1g-dev"
 RUN set -xe && \
     apt-get update && apt-get install -y --no-install-recommends ${RUNTIME_DEPS} && \
     cd ${PHP_SRC_DIR} && make -j "$(nproc)" PHP_SAPI=embed install-sapi install-headers && \

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,13 @@ VERSION     := $(shell git describe --tags --always --dirty="-dev")
 
 # Generic build options.
 PACKAGE_FORMAT := tar.xz
-PHP_VERSION    := 7.0.27
+PHP_VERSION    := 7.0.30
 DOCKER_IMAGE   := deuill/$(NAME):$(PHP_VERSION)
+STATIC         := false
 
 # Go build options.
 GO   := go
-TAGS := -tags 'php$(word 1,$(subst ., ,$(PHP_VERSION)))'
+TAGS := -tags 'php$(word 1,$(subst ., ,$(PHP_VERSION))) $(if $(findstring true,$(STATIC)),static)'
 
 # Install options.
 PREFIX := /usr
@@ -20,25 +21,12 @@ PREFIX := /usr
 VERBOSE :=
 
 # Variables to pass down to sub-invocations of 'make'.
-MAKE_OPTIONS := PACKAGE_FORMAT=$(PACKAGE_FORMAT) PHP_VERSION=$(PHP_VERSION) GO=$(GO) PREFIX=$(PREFIX) VERBOSE=$(VERBOSE)
+MAKE_OPTIONS := PACKAGE_FORMAT=$(PACKAGE_FORMAT) PHP_VERSION=$(PHP_VERSION) GO=$(GO) PREFIX=$(PREFIX) VERBOSE=$(VERBOSE) STATIC=$(STATIC)
 
-## Default action. Build binary distribution.
-all: $(NAME)
-
-$(NAME): .build/env/GOPATH/.ok
+## Build binary distribution for library.
+build: .build/env/GOPATH/.ok
 	@echo "Building '$(NAME)'..."
 	$Q $(GO) install $(if $(VERBOSE),-v) $(TAGS) $(IMPORT_PATH)
-
-## Print internal package list.
-list: .build/env/GOPATH/.ok
-	@echo $(PACKAGES)
-
-## Install binary distribution to directory, accepts DESTDIR argument.
-install: $(NAME)
-	@echo "Installing '$(NAME)'..."
-	$Q mkdir -p $(DESTDIR)/etc/$(NAME)
-	$Q cp -a dist/conf/. $(DESTDIR)/etc/$(NAME)
-	$Q install -Dm 0755 .build/env/GOPATH/bin/$(NAME) $(DESTDIR)$(PREFIX)/bin/$(NAME)
 
 ## Run test for all local packages or specified PACKAGE.
 test: .build/env/GOPATH/.ok
@@ -62,9 +50,6 @@ cover: .build/env/GOPATH/.ok
 	@echo "Total coverage for '$(NAME)':"
 	$Q $(GO) tool cover -func .build/tmp/cover.merged
 
-## Package binary distribution to file, accepts PACKAGE_FORMAT argument.
-package: clean $(NAME)_$(VERSION).$(PACKAGE_FORMAT)
-
 ## Remove temporary files and packages required for build.
 clean:
 	@echo "Cleaning '$(NAME)'..."
@@ -82,7 +67,7 @@ help:
 	    $(MAKEFILE_LIST)
 	@printf "\n"
 
-.PHONY: $(NAME) all install package test cover clean
+.PHONY: build test cover clean
 
 .DEFAULT:
 	$Q $(MAKE) -s -f $(MAKEFILE) help
@@ -90,7 +75,7 @@ help:
 # Pull or build Docker image for PHP version specified.
 docker-image:
 	$Q docker image pull $(DOCKER_IMAGE) ||                \
-	   docker build --build-arg=PHP_VERSION=$(PHP_VERSION) \
+	   docker build --build-arg=PHP_VERSION=$(PHP_VERSION) --build-arg=STATIC=$(STATIC) \
 	                -t $(DOCKER_IMAGE) -f Dockerfile .     \
 
 # Run Make target in Docker container. For instance, to run 'test', call as 'docker-test'.
@@ -98,20 +83,6 @@ docker-%: docker-image
 	$Q docker run --rm -e GOPATH="/tmp/go"                                  \
 	              -v "$(CURDIR):/tmp/go/src/$(IMPORT_PATH)" $(DOCKER_IMAGE) \
 	                 "$(MAKE) -C /tmp/go/src/$(IMPORT_PATH) $(word 2,$(subst -, ,$@)) $(MAKE_OPTIONS)"
-
-$(NAME)_$(VERSION).tar.xz: .build/dist/.ok
-	@echo "Building 'tar' package for '$(NAME)'..."
-	$Q fakeroot -- tar -cJf $(NAME)_$(VERSION).tar.xz -C .build/dist .
-
-$(NAME)_$(VERSION).deb: .build/dist/.ok
-	@echo "Building 'deb' package for '$(NAME)'..."
-	$Q fakeroot -- fpm -f -s dir -t deb                                   \
-	                   -n $(NAME) -v $(VERSION) -p $(NAME)_$(VERSION).deb \
-	                   -C .build/dist
-
-.build/dist/.ok:
-	$Q mkdir -p .build/dist && touch $@
-	$Q $(MAKE) -s -f $(MAKEFILE) DESTDIR=".build/dist" install
 
 .build/env/GOPATH/.ok:
 	$Q mkdir -p "$(dir .build/env/GOPATH/src/$(IMPORT_PATH))" && touch $@

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@ IMPORT_PATH := github.com/deuill/$(NAME)
 VERSION     := $(shell git describe --tags --always --dirty="-dev")
 
 # Generic build options.
-PACKAGE_FORMAT := tar.xz
 PHP_VERSION    := 7.0.30
-DOCKER_IMAGE   := deuill/$(NAME):$(PHP_VERSION)
 STATIC         := false
+DOCKER_IMAGE   := deuill/$(NAME):$(PHP_VERSION)
 
 # Go build options.
 GO   := go
@@ -21,7 +20,7 @@ PREFIX := /usr
 VERBOSE :=
 
 # Variables to pass down to sub-invocations of 'make'.
-MAKE_OPTIONS := PACKAGE_FORMAT=$(PACKAGE_FORMAT) PHP_VERSION=$(PHP_VERSION) GO=$(GO) PREFIX=$(PREFIX) VERBOSE=$(VERBOSE) STATIC=$(STATIC)
+MAKE_OPTIONS := PHP_VERSION=$(PHP_VERSION) GO=$(GO) PREFIX=$(PREFIX) VERBOSE=$(VERBOSE) STATIC=$(STATIC)
 
 ## Build binary distribution for library.
 build: .build/env/GOPATH/.ok

--- a/php7-static.go
+++ b/php7-static.go
@@ -6,5 +6,5 @@
 
 package php
 
-// #cgo LDFLAGS: -ldl -lm -lssl -lcrypto -lreadline -lresolv -lpcre -lz -lxml2
+// #cgo LDFLAGS: -ldl -lm -lcurl -lpcre -lssl -lcrypto -lresolv -ledit -lz -lxml2
 import "C"


### PR DESCRIPTION
This allows for building binaries against `go-php` without needing an accompanying version of the
PHP library. To build a static version of `go-php`, simply set `STATIC=true` as a Make flag, e.g.:

    make docker-build STATIC=true

The resulting `go-php` library will be placed in `.build/env/GOPATH/pkg/...` by default, and can be
used directly, but using the Docker image as a build environment will also work.