### PR TITLE
Fix "warning: initialization from incompatible pointer type"

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -63,7 +63,11 @@ static void engine_register_variables(zval *track_vars_array) {
 	php_import_environment_variables(track_vars_array);
 }
 
+#if PHP_VERSION_ID < 70100
+static void engine_log_message(char *str) {
+#else
 static void engine_log_message(char *str, int syslog_type_int) {
+#endif
 	engine_context *context = SG(server_context);
 
 	engineWriteLog(context, (void *) str, strlen(str));

--- a/engine.c
+++ b/engine.c
@@ -63,7 +63,7 @@ static void engine_register_variables(zval *track_vars_array) {
 	php_import_environment_variables(track_vars_array);
 }
 
-static void engine_log_message(char *str) {
+static void engine_log_message(char *str, int syslog_type_int) {
 	engine_context *context = SG(server_context);
 
 	engineWriteLog(context, (void *) str, strlen(str));


### PR DESCRIPTION
This pull request fixes the following error:

```
engine.c:97:2: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
  engine_log_message,          // Log Message
  ^~~~~~~~~~~~~~~~~~
engine.c:97:2: note: (near initialization for ‘engine_module.log_message’)
```

The extra parameter *syslog_type_int* was introduced in PHP 7.1, see [this commit](https://github.com/php/php-src/commit/2809a676b55cebd4c6f8a8895ffe286db0704e87).
