### PR TITLE
Continue running the go program after exit() in PHP

### DIFF
--- a/context.c
+++ b/context.c
@@ -36,7 +36,7 @@ engine_context *context_new() {
 	return context;
 }
 
-void context_exec(engine_context *context, char *filename) {
+void context_exec(engine_context *context, char *filename, int *exit) {
 	int ret;
 
 	// Attempt to execute script file.
@@ -48,9 +48,11 @@ void context_exec(engine_context *context, char *filename) {
 		script.opened_path = NULL;
 		script.free_filename = 0;
 
-		ret = php_execute_script(&script);
+		ret = zend_execute_scripts(ZEND_REQUIRE, NULL, 1, &script);
+		*exit = -1;
 	} zend_catch {
-		errno = 1;
+		errno = 0;
+		*exit = EG(exit_status);
 		return;
 	} zend_end_try();
 
@@ -63,7 +65,7 @@ void context_exec(engine_context *context, char *filename) {
 	return;
 }
 
-void *context_eval(engine_context *context, char *script) {
+void *context_eval(engine_context *context, char *script, int *exit) {
 	zval *str = _value_init();
 	_value_set_string(&str, script);
 
@@ -84,7 +86,13 @@ void *context_eval(engine_context *context, char *script) {
 
 	// Attempt to execute compiled string.
 	zval tmp;
-	_context_eval(op, &tmp);
+	_context_eval(op, &tmp, exit);
+
+	// Script called exit()
+	if (*exit != -1) {
+		errno = 0;
+		return NULL;
+	}
 
 	// Allocate result value and copy temporary execution result in.
 	zval *result = malloc(sizeof(zval));

--- a/context.go
+++ b/context.go
@@ -34,6 +34,14 @@ type Context struct {
 	values  []*Value
 }
 
+type ExitError struct {
+	Status int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("Exitcode %d", e.Status)
+}
+
 // Bind allows for binding Go values into the current execution context under
 // a certain name. Bind returns an error if attempting to bind an invalid value
 // (check the documentation for NewValue for what is considered to be a "valid"
@@ -59,10 +67,16 @@ func (c *Context) Bind(name string, val interface{}) error {
 func (c *Context) Exec(filename string) error {
 	f := C.CString(filename)
 	defer C.free(unsafe.Pointer(f))
+	var e C.int
 
-	_, err := C.context_exec(c.context, f)
+	_, err := C.context_exec(c.context, f, &e)
 	if err != nil {
 		return fmt.Errorf("Error executing script '%s' in context", filename)
+	}
+
+	code := int(e)
+	if code != -1 {
+		return &ExitError{code}
 	}
 
 	return nil
@@ -74,10 +88,16 @@ func (c *Context) Exec(filename string) error {
 func (c *Context) Eval(script string) (*Value, error) {
 	s := C.CString(script)
 	defer C.free(unsafe.Pointer(s))
+	var e C.int
 
-	result, err := C.context_eval(c.context, s)
+	result, err := C.context_eval(c.context, s, &e)
 	if err != nil {
 		return nil, fmt.Errorf("Error executing script '%s' in context", script)
+	}
+
+	code := int(e)
+	if code != -1 {
+		return nil, &ExitError{code}
 	}
 
 	defer C.free(result)

--- a/context_test.go
+++ b/context_test.go
@@ -284,8 +284,8 @@ func TestContextBind(t *testing.T) {
 }
 
 var exitTests = []struct {
-	code 		 int
-	script   string
+	code   int
+	script string
 }{
 	{
 		0,
@@ -299,13 +299,17 @@ var exitTests = []struct {
 		255,
 		"exit(255);",
 	},
+	{
+		255,
+		"trigger_error('test', E_USER_ERROR);",
+	},
 }
 
 func TestContextExecExit(t *testing.T) {
 	c, _ := e.NewContext()
 
 	for _, tt := range exitTests {
-		script, err := NewScript("exit", "<?php " + tt.script)
+		script, err := NewScript("exit", "<?php "+tt.script)
 		if err != nil {
 			t.Errorf("Could not create temporary file for testing")
 			continue

--- a/context_test.go
+++ b/context_test.go
@@ -283,6 +283,71 @@ func TestContextBind(t *testing.T) {
 	c.Destroy()
 }
 
+var exitTests = []struct {
+	code 		 int
+	script   string
+}{
+	{
+		0,
+		"exit(0);",
+	},
+	{
+		1,
+		"exit(1);",
+	},
+	{
+		255,
+		"exit(255);",
+	},
+}
+
+func TestContextExecExit(t *testing.T) {
+	c, _ := e.NewContext()
+
+	for _, tt := range exitTests {
+		script, err := NewScript("exit", "<?php " + tt.script)
+		if err != nil {
+			t.Errorf("Could not create temporary file for testing")
+			continue
+		}
+
+		err = c.Exec(script.Name())
+		script.Remove()
+
+		exit, ok := err.(*ExitError)
+		if !ok {
+			t.Errorf("Expected an ExitError, have %v", err)
+			continue
+		}
+
+		if exit.Status != tt.code {
+			t.Errorf("Expected an exitcode of %d, have %d", tt.code, exit.Status)
+		}
+	}
+
+	c.Destroy()
+}
+
+func TestContextEvalExit(t *testing.T) {
+	c, _ := e.NewContext()
+
+	for _, tt := range exitTests {
+		_, err := c.Eval(tt.script)
+
+		exit, ok := err.(*ExitError)
+		if !ok {
+			t.Errorf("Expected an ExitError, have %v", err)
+			continue
+		}
+
+		if exit.Status != tt.code {
+			t.Errorf("Expected an exitcode of %d, have %d", tt.code, exit.Status)
+		}
+	}
+
+	c.Destroy()
+}
+
 func TestContextDestroy(t *testing.T) {
 	c, _ := e.NewContext()
 	c.Destroy()

--- a/engine.c
+++ b/engine.c
@@ -19,6 +19,7 @@ const char engine_ini_defaults[] = {
 	"expose_php = 0\n"
 	"default_mimetype =\n"
 	"html_errors = 0\n"
+	"error_reporting = E_ALL\n"
 	"register_argc_argv = 1\n"
 	"implicit_flush = 1\n"
 	"output_buffering = 0\n"

--- a/include/context.h
+++ b/include/context.h
@@ -9,8 +9,8 @@ typedef struct _engine_context {
 } engine_context;
 
 engine_context *context_new();
-void context_exec(engine_context *context, char *filename);
-void *context_eval(engine_context *context, char *script);
+void context_exec(engine_context *context, char *filename, int *exit);
+void *context_eval(engine_context *context, char *script, int *exit);
 void context_bind(engine_context *context, char *name, void *value);
 void context_destroy(engine_context *context);
 

--- a/include/php7/_context.h
+++ b/include/php7/_context.h
@@ -6,6 +6,6 @@
 #define ___CONTEXT_H___
 
 static void _context_bind(char *name, zval *value);
-static void _context_eval(zend_op_array *op, zval *ret);
+static void _context_eval(zend_op_array *op, zval *ret, int *exit);
 
 #endif

--- a/src/php5/_context.c
+++ b/src/php5/_context.c
@@ -6,7 +6,7 @@ static void _context_bind(char *name, zval *value) {
 	ZEND_SET_SYMBOL(EG(active_symbol_table), name, value);
 }
 
-static void _context_eval(zend_op_array *op, zval *ret) {
+static void _context_eval(zend_op_array *op, zval *ret, int *exit) {
 	zend_op_array *oparr = EG(active_op_array);
 	zval *retval = NULL;
 	zval **retvalptr = EG(return_value_ptr_ptr);
@@ -25,10 +25,9 @@ static void _context_eval(zend_op_array *op, zval *ret) {
 
 	zend_try {
 		zend_execute(op);
+		*exit = -1;
 	} zend_catch {
-		destroy_op_array(op);
-		efree(op);
-		zend_bailout();
+		*exit = EG(exit_status);
 	} zend_end_try();
 
 	destroy_op_array(op);

--- a/src/php7/_context.c
+++ b/src/php7/_context.c
@@ -6,16 +6,15 @@ static void _context_bind(char *name, zval *value) {
 	zend_hash_str_update(&EG(symbol_table), name, strlen(name), value);
 }
 
-static void _context_eval(zend_op_array *op, zval *ret) {
+static void _context_eval(zend_op_array *op, zval *ret, int *exit) {
 	EG(no_extensions) = 1;
 
-	zend_try {
+	zend_first_try {
 		ZVAL_NULL(ret);
 		zend_execute(op, ret);
+		*exit = -1;
 	} zend_catch {
-		destroy_op_array(op);
-		efree_size(op, sizeof(zend_op_array));
-		zend_bailout();
+		*exit = EG(exit_status);
 	} zend_end_try();
 
 	destroy_op_array(op);


### PR DESCRIPTION
Currently, if a PHP script calls `exit()`, not only does the script terminate, but also the GO binary running it - see #31. This pull request changes this in a backwards-compatible way`*` such that calls to `Exec()` and `Eval()` will return an error which can be checked for.

### Example

```golang
val, err := context.Eval(script);

if err != nil {
    if exit, ok := err.(*php.ExitError); ok {
        fmt.Printf("PHP exited with exit status %d\n", exit.Status)
    } else {
        fmt.Printf("Could not execute script %s: %v", script, err)
    }
}
```

`*`: ...instead of changing the return types, or introducing any global state in context, or adding new methods. The API is modeled a bit after os/exec