### PR TITLE
Add Ini() method to change ini values on an engine context

### DIFF
--- a/context.c
+++ b/context.c
@@ -99,6 +99,10 @@ void context_bind(engine_context *context, char *name, void *value) {
 	_context_bind(name, v->internal);
 }
 
+void context_ini(engine_context *context, char *name, char *value) {
+	_context_ini(name, value);
+}
+
 void context_destroy(engine_context *context) {
 	php_request_shutdown(NULL);
 

--- a/context.go
+++ b/context.go
@@ -53,6 +53,18 @@ func (c *Context) Bind(name string, val interface{}) error {
 	return nil
 }
 
+// Ini allows setting ini file values into the current execution context.
+func (c *Context) Ini(name, value string) error {
+	n := C.CString(name)
+	defer C.free(unsafe.Pointer(n))
+	v := C.CString(value)
+	defer C.free(unsafe.Pointer(v))
+
+	_, err := C.context_ini(c.context, n, v)
+
+	return err
+}
+
 // Exec executes a PHP script pointed to by filename in the current execution
 // context, and returns an error, if any. Output produced by the script is
 // written to the context's pre-defined io.Writer instance.

--- a/context_test.go
+++ b/context_test.go
@@ -283,6 +283,24 @@ func TestContextBind(t *testing.T) {
 	c.Destroy()
 }
 
+func TestContextIni(t *testing.T) {
+	c, _ := e.NewContext()
+	defer c.Destroy()
+
+	path := "/path/set/by/go"
+	c.Ini("include_path", path)
+
+	val, err := c.Eval("return ini_get('include_path');")
+	if err != nil {
+		t.Errorf("Unexpected error while running script: %v", err)
+		return
+	}
+
+	if val.String() != path {
+		t.Errorf("Expected %s, have %s", path, val.String())
+	}
+}
+
 func TestContextDestroy(t *testing.T) {
 	c, _ := e.NewContext()
 	c.Destroy()

--- a/include/context.h
+++ b/include/context.h
@@ -9,8 +9,8 @@ typedef struct _engine_context {
 } engine_context;
 
 engine_context *context_new();
-void context_exec(engine_context *context, char *filename, int *exit);
-void *context_eval(engine_context *context, char *script, int *exit);
+void context_exec(engine_context *context, char *filename);
+void *context_eval(engine_context *context, char *script);
 void context_bind(engine_context *context, char *name, void *value);
 void context_ini(engine_context *context, char *name, char *value);
 void context_destroy(engine_context *context);

--- a/include/context.h
+++ b/include/context.h
@@ -9,9 +9,10 @@ typedef struct _engine_context {
 } engine_context;
 
 engine_context *context_new();
-void context_exec(engine_context *context, char *filename);
-void *context_eval(engine_context *context, char *script);
+void context_exec(engine_context *context, char *filename, int *exit);
+void *context_eval(engine_context *context, char *script, int *exit);
 void context_bind(engine_context *context, char *name, void *value);
+void context_ini(engine_context *context, char *name, char *value);
 void context_destroy(engine_context *context);
 
 #include "_context.h"

--- a/include/php5/_context.h
+++ b/include/php5/_context.h
@@ -6,6 +6,7 @@
 #define ___CONTEXT_H___
 
 static void _context_bind(char *name, zval *value);
+static void _context_ini(char *name, char *value);
 static void _context_eval(zend_op_array *op, zval *ret);
 
 #endif

--- a/include/php7/_context.h
+++ b/include/php7/_context.h
@@ -7,5 +7,6 @@
 
 static void _context_bind(char *name, zval *value);
 static void _context_eval(zend_op_array *op, zval *ret);
+static void _context_ini(char *name, char *value);
 
 #endif

--- a/src/php5/_context.c
+++ b/src/php5/_context.c
@@ -6,6 +6,12 @@ static void _context_bind(char *name, zval *value) {
 	ZEND_SET_SYMBOL(EG(active_symbol_table), name, value);
 }
 
+static void _context_ini(char *name, char *value) {
+	if (zend_alter_ini_entry_ex(name, strlen(name) + 1, value, strlen(value) + 1, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0) == FAILURE) {
+		errno = 1;
+	}
+}
+
 static void _context_eval(zend_op_array *op, zval *ret) {
 	zend_op_array *oparr = EG(active_op_array);
 	zval *retval = NULL;

--- a/src/php7/_context.c
+++ b/src/php7/_context.c
@@ -6,6 +6,17 @@ static void _context_bind(char *name, zval *value) {
 	zend_hash_str_update(&EG(symbol_table), name, strlen(name), value);
 }
 
+static void _context_ini(char *name, char *value) {
+	zend_string *n, *v;
+
+	// Use "permanent" strings
+	n = zend_string_init(name, strlen(name), 1);
+	v = zend_string_init(value, strlen(value), 1);
+	if (zend_alter_ini_entry_ex(n, v, PHP_INI_USER, PHP_INI_STAGE_RUNTIME, 0) == FAILURE) {
+		errno = 1;
+	}
+}
+
 static void _context_eval(zend_op_array *op, zval *ret) {
 	EG(no_extensions) = 1;
 


### PR DESCRIPTION
Example usage:

```golang
context, _:= engine.NewContext()
if err != nil {
  fmt.Printf("Could not create a new context: %v", err)
  os.Exit(1)
}
defer context.Destroy()

// Set ini file values here
context.Ini("include_path", ".:/path/to/php/includes")
context.Ini("date.timezone", "Europe/Berlin")

// Now run script using Exec() or Eval().
context.Eval("...");
```
